### PR TITLE
Support multiple labels

### DIFF
--- a/Example/SampleApp/SampleAppTests/AllureLabelsTests.swift
+++ b/Example/SampleApp/SampleAppTests/AllureLabelsTests.swift
@@ -20,4 +20,12 @@ final class AllureLabelsTests: XCTestCase {
 
         XCTFail()
     }
+
+    func testTags() {
+        Allure.tag("tag one")
+        Allure.tag("tag two")
+        Allure.tag("tag three")
+
+        XCTFail()
+    }
 }

--- a/Sources/AllureXCTest/Allure.swift
+++ b/Sources/AllureXCTest/Allure.swift
@@ -85,6 +85,10 @@ public enum Allure {
     public static func resultFormat(_ format: String) {
         labelStep(key: "resultFormat", value: format)
     }
+
+    public static func label(key: String, value: String) {
+        labelStep(key: key, value: value)
+    }
 }
 
 extension Allure {


### PR DESCRIPTION
**Summary**
This PR adds support for multiple labels in the Allure report integration.
Also, allow custom labels in the json report

**Motivation**
Currently, it's only possible to assign a single tag to a test case. 
In many scenarios, it's useful to associate multiple tags (e.g., different test packs (regression, sanity, etc...) for better filtering and organisation in the report.
There was also no support for adding custom labels to the JSON report, limiting flexibility for users who want to define their own metadata.

**Changes**
Updated the label-handling logic to allow multiple labels per test case.
Modified internal data structures to support an array of labels.

**Example Usage**
```swift
func testTags() {
    Allure.tag("tag one")
    Allure.tag("tag two")
    Allure.tag("tag three")
    ...
}
```
    
**Notes**
This change is backward-compatible with existing single-label usage.