### PR TITLE
Add Links support

### DIFF
--- a/Example/SampleApp/SampleAppTests/AllureLabelsTests.swift
+++ b/Example/SampleApp/SampleAppTests/AllureLabelsTests.swift
@@ -28,4 +28,11 @@ final class AllureLabelsTests: XCTestCase {
 
         XCTFail()
     }
+
+    func testLinks() {
+        Allure.link(name: "ExampleIssue", type: .issue, url: "www.example.com")
+        Allure.link(name: "ExampleTms", type: .tms, url: "www.example.com")
+
+        XCTAssertTrue(2 + 2 == 4)
+    }
 }

--- a/Sources/AllureXCTest/Allure+Labels.swift
+++ b/Sources/AllureXCTest/Allure+Labels.swift
@@ -1,6 +1,6 @@
 //
-//  Allure.swift
-//  
+//  Allure+Labels.swift
+//
 //
 //  Created by Vladislav Kiryukhin on 07.11.2022.
 //

--- a/Sources/AllureXCTest/Allure+Links.swift
+++ b/Sources/AllureXCTest/Allure+Links.swift
@@ -1,0 +1,36 @@
+//
+//  Allure+Links.swift
+//
+//
+//  Created by Miguel Franco on 14.05.2025.
+//
+
+import XCTest
+
+/// Helper class to make an opportunity to add Allure links to XCTest
+/// https://github.com/allure-framework/allure2/blob/2.20.0/allure-plugin-api/src/main/java/io/qameta/allure/entity/Link.java
+extension Allure {
+    public static func link(
+        name: String,
+        type: LinkType,
+        url: String
+    ) {
+        linkStep(
+            name: name,
+            type: type,
+            url: url
+        )
+    }
+}
+
+extension Allure {
+    fileprivate static func linkStep(
+        name: String,
+        type: LinkType,
+        url: String,
+        linkPattern:String = "https://"
+    ) {
+        let finalURL = url.hasPrefix(linkPattern) ? url : "\(linkPattern)\(url)"
+        XCTContext.empty(with: "allure_link_\(name)_\(type.rawValue)_\(finalURL)")
+    }
+}

--- a/Sources/AllureXCTest/LinkType.swift
+++ b/Sources/AllureXCTest/LinkType.swift
@@ -1,0 +1,39 @@
+//
+//  LinkType.swift
+//
+//
+//  Created by Miguel Franco on 14.05.2025.
+//
+
+import Foundation
+
+public enum LinkType {
+    case tms
+    case issue
+    case custom(String?)
+}
+
+extension LinkType: RawRepresentable {
+    public typealias RawValue = String
+    public var rawValue: String {
+        switch self {
+        case .tms:
+            return "tms"
+        case .issue:
+            return "issue"
+        case .custom(let value):
+            return value ?? "custom"
+        }
+    }
+
+    public init(rawValue: String) {
+        switch rawValue {
+        case "tms":
+            self = .tms
+        case "issue":
+            self = .issue
+        default:
+            self = .custom(rawValue)
+        }
+    }
+}


### PR DESCRIPTION
**Summary**
This PR adds support for including links in the Allure report.

**Motivation**
Allure reports currently lack the ability to include clickable links in test results. This feature is useful for linking to related resources such as:

**Test case documentation**
Bug tracker issues
External logs or dashboards
Requirement or ticket references
Adding support for links improves traceability and enhances the usefulness of test reports.

**Changes**
Added support for injecting one or more links into the Allure JSON report for each test case.
Each link includes a name, type, and URL, following the Allure link format.
Updated relevant logic to process and serialize links correctly.
Added test coverage to validate the appearance of links in the report output.

**Example Usage**
```swift
func testLinks() {
    Allure.link(name: "ExampleIssue", type: .issue, url: "www.example.com")
    Allure.link(name: "ExampleTms", type: .tms, url: "www.example.com")

     ...
}
```

**Notes**
Fully backward-compatible.
Supports multiple links per test case.
Link types (e.g., "issue", "tms", "custom") are flexible and align with Allure standards.